### PR TITLE
Fix typo causing heap-buffer-overflow when reading the FASTA header

### DIFF
--- a/GDB.c
+++ b/GDB.c
@@ -741,7 +741,7 @@ FILE **Create_GDB(GDB *gdb, char *spath, int ftype, int bps, char *tpath)
     
           if (hdrtot + len + 1 > hdrtop)
             { hdrtop = 1.2*(hdrtot+len+1) + 10000;
-              headers = realloc(headers,hdrtot);
+              headers = realloc(headers,hdrtop);
               if (headers == NULL)
                 { EPRINTF(EPLACE,"%s: Out of memory creating GDB for %s\n",Prog_Name,spath);
                   goto error2;


### PR DESCRIPTION
The typo was preventing reallocating the `headers` to the correct size, causing the following `memcpy` to cause a heap buffer overflow, leading to a segmentation fault.