### PR TITLE
Fix FastGAN build target to use correct source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ libfastk.h: gene_core.h
 GDB.c: gene_core.c gene_core.h
 GDB.h: gene_core.h
 
-FastGAN: FastGA.new.c libfastk.c libfastk.h GDB.c GDB.h RSDsort.c align.c align.h alncode.c alncode.h ONElib.c ONElib.h
-	$(CC) $(CFLAGS) -o FastGAN FastGA.new.c RSDsort.c libfastk.c align.c GDB.c alncode.c gene_core.c ONElib.c -lpthread -lm -lz
+FastGAN: FastGA.c libfastk.c libfastk.h GDB.c GDB.h RSDsort.c align.c align.h alncode.c alncode.h ONElib.c ONElib.h
+	$(CC) $(CFLAGS) -o FastGAN FastGA.c RSDsort.c libfastk.c align.c GDB.c alncode.c gene_core.c ONElib.c -lpthread -lm -lz
 
 FAtoGDB: FAtoGDB.c GDB.c GDB.h ONElib.c ONElib.h
 	$(CC) $(CFLAGS) -o FAtoGDB FAtoGDB.c GDB.c gene_core.c ONElib.c -lm -lz


### PR DESCRIPTION
## Summary

- Fixes build failure caused by missing `FastGA.new.c` file
- Changes FastGAN target in Makefile to use existing `FastGA.c` instead

## Problem

The Makefile references `FastGA.new.c` which does not exist in the repository, causing make to fail with:
```
make: *** No rule to make target 'FastGA.new.c', needed by 'FastGAN'.  Stop.
```

## Solution

Updated the FastGAN target dependency and compilation command to use `FastGA.c`, which is the actual source file present in the codebase.

## Test Plan

- [x] Build completes successfully with `make`
- [x] All binaries build without errors (FastGAN, FastGA, FastKS, and all other tools)
- [x] `make install` works correctly