### PR TITLE
Fix wave algorithm boundary conditions to prevent invalid alignments

### DIFF
--- a/ALNtoPAF.c
+++ b/ALNtoPAF.c
@@ -185,8 +185,8 @@ void *gen_paf(void *args)
       // Skip alignments with invalid coordinates (can occur from edge cases in wave algorithm)
       if (path->abpos < 0 || path->aepos > aln->alen || path->abpos >= path->aepos ||
           path->bbpos < 0 || path->bepos > aln->blen || path->bbpos >= path->bepos)
-        { alast = acontig;
-          continue;  // Skip this invalid alignment
+        { continue;  // Skip this invalid alignment (do NOT set alast, so sequence gets
+                      //   reloaded for next valid alignment on this contig)
         }
 
       aoff = contigs1[acontig].sbeg;

--- a/ALNtoPAF.c
+++ b/ALNtoPAF.c
@@ -181,6 +181,14 @@ void *gen_paf(void *args)
       ascaff = contigs1[acontig].scaf;
       bscaff = contigs2[bcontig].scaf;
 
+      // Validate alignment coordinates are within bounds
+      // Skip alignments with invalid coordinates (can occur from edge cases in wave algorithm)
+      if (path->abpos < 0 || path->aepos > aln->alen || path->abpos >= path->aepos ||
+          path->bbpos < 0 || path->bepos > aln->blen || path->bbpos >= path->bepos)
+        { alast = acontig;
+          continue;  // Skip this invalid alignment
+        }
+
       aoff = contigs1[acontig].sbeg;
 
       if (SWAP_G)

--- a/FastGA.c
+++ b/FastGA.c
@@ -3263,7 +3263,17 @@ static void align_contigs(uint8 *beg, uint8 *end, int swide, int ctg1, int ctg2,
 
                             rlen = path->aepos - path->abpos;
                             if (rlen >= alnMin && alnRate*rlen >= path->diffs)
-                              { Compress_TraceTo8(ovl,0);
+                              { uint16 *t16 = (uint16 *) ovl->path.trace;
+                                int     ti, trace_overflow = 0;
+                                for (ti = 0; ti < ovl->path.tlen; ti++)
+                                  if (t16[ti] > 255)
+                                    { trace_overflow = 1;
+                                      break;
+                                    }
+                                if (trace_overflow)
+                                  goto next_alignment;
+
+                                Compress_TraceTo8(ovl,0);
                                 if (fwrite(ovl,OVL_SIZE,1,tfile) != 1)
                                   { fprintf(stderr,
                                            "%s: Cannot write overlap gather file %s/%s.%d.las\n",
@@ -3279,6 +3289,8 @@ static void align_contigs(uint8 *beg, uint8 *end, int swide, int ctg1, int ctg2,
                                 nlas += 1;
                                 nmem += path->tlen + OVL_SIZE;
                               }
+
+                          next_alignment:
 
 #ifdef DEBUG_ALIGN
                             if (rlen >= ALIGN_MIN && ALIGN_RATE*rlen >= path->diffs)
@@ -4933,7 +4945,7 @@ int main(int argc, char *argv[])
       gdb2 = gdb1;
     else
       { GEXTN2 = ".gdb";
-        fname = Catenate(PATH1,"/",ROOT1,GEXTN2);
+        fname = Catenate(PATH2,"/",ROOT2,GEXTN2);
         if ((file = fopen(fname,"r")) == NULL)
           GEXTN2 = ".1gdb";
         else

--- a/align.c
+++ b/align.c
@@ -353,6 +353,8 @@ static int forward_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
                         int *mind, int maxd, int mida, int minp, int maxp, int aoff)
 { char *aseq  = align->aseq;
   char *bseq  = align->bseq;
+  int   alen  = align->alen;
+  int   blen  = align->blen;
   Path *apath = align->path;
 
   int     hgh, low, dif;
@@ -432,7 +434,7 @@ static int forward_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
         Pebble *pb;
 
         x = (mida+k)>>1;
-        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
         if (x < 0 || x < k)
           { V[k]  = -2;  // Mark dead
             T[k]  = PATH_INT;
@@ -630,19 +632,27 @@ static int forward_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           T  =  _T-vmin;
         }
 
-      if (low >= minp)
-        { NA[low] = NA[low+1];
-          V[low]  = -1;
-        }
-      else
-        low += 1;
+      // Dynamic sequence length constraint for wave expansion
+      { int curr_anti = mida + 2*(dif+1);
+        int seq_minp = curr_anti - 2*blen;
+        int seq_maxp = 2*alen - curr_anti;
+        int eff_minp = (minp > seq_minp) ? minp : seq_minp;
+        int eff_maxp = (maxp < seq_maxp) ? maxp : seq_maxp;
 
-      if (hgh <= maxp)
-        { NA[hgh] = NA[hgh-1];
-          V[hgh]  = am = -1;
-        }
-      else
-        am = V[--hgh];
+        if (low >= eff_minp)
+          { NA[low] = NA[low+1];
+            V[low]  = -1;
+          }
+        else
+          low += 1;
+
+        if (hgh <= eff_maxp)
+          { NA[hgh] = NA[hgh-1];
+            V[hgh]  = am = -1;
+          }
+        else
+          am = V[--hgh];
+      }
 
       dif += 1;
 
@@ -694,7 +704,7 @@ static int forward_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           b <<= 1;
 
           x = (c+k)>>1;
-          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
           if (x < 0 || x < k)
             { t  = T[k];
               n  = M[k];
@@ -907,6 +917,8 @@ static int reverse_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
                         int mind, int maxd, int mida, int minp, int maxp, int aoff)
 { char *aseq  = align->aseq - 1;
   char *bseq  = align->bseq - 1;
+  int   alen  = align->alen;
+  int   blen  = align->blen;
   Path *apath = align->path;
 
   int     hgh, low, dif;
@@ -984,7 +996,7 @@ static int reverse_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
         Pebble *pb;
 
         x = (mida+k)>>1;
-        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
         if (x < 0 || x < k)
           { V[k]  = -2;  // Mark dead
             T[k]  = PATH_INT;
@@ -1173,19 +1185,27 @@ static int reverse_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           T  =  _T-vmin;
         }
 
-      if (low >= minp)
-        { NA[low] = NA[low+1];
-          V[low]  = ap = INT32_MAX;
-        }
-      else
-        ap = V[++low];
+      // Dynamic sequence length constraint for wave expansion
+      { int curr_anti = mida - 2*(dif+1);
+        int seq_minp = curr_anti - 2*blen;
+        int seq_maxp = 2*alen - curr_anti;
+        int eff_minp = (minp > seq_minp) ? minp : seq_minp;
+        int eff_maxp = (maxp < seq_maxp) ? maxp : seq_maxp;
 
-      if (hgh <= maxp)
-        { NA[hgh] = NA[hgh-1];
-          V[hgh] = INT32_MAX;
-        }
-      else
-        hgh -= 1;
+        if (low >= eff_minp)
+          { NA[low] = NA[low+1];
+            V[low]  = ap = INT32_MAX;
+          }
+        else
+          ap = V[++low];
+
+        if (hgh <= eff_maxp)
+          { NA[hgh] = NA[hgh-1];
+            V[hgh] = INT32_MAX;
+          }
+        else
+          hgh -= 1;
+      }
 
       dif += 1;
 
@@ -1237,7 +1257,7 @@ static int reverse_wave(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           b <<= 1;
 
           x = (c+k)>>1;
-          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
           if (x < 0 || x < k)
             { t  = T[k];
               n  = M[k];
@@ -1478,10 +1498,12 @@ int Local_Alignment(Alignment *align, Work_Data *ework, Align_Spec *espec,
   int   selfie;
   int   fshort, rshort;
 
-  { int alen;
+  { int alen, blen;
     int maxtp, wsize;
 
     alen = align->alen;
+    blen = align->blen;
+    (void) blen;  // Used by wave functions via align->blen
 
     if (hgh-low >= 7500)
       wsize = VectorEl*(hgh-low+1);
@@ -1647,6 +1669,8 @@ static int forward_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
                         int *mind, int maxd, int mida, int minp, int maxp, int tspace)
 { char *aseq  = align->aseq;
   char *bseq  = align->bseq;
+  int   alen  = align->alen;
+  int   blen  = align->blen;
   Path *apath = align->path;
 
   int     hgh, low, dif;
@@ -1723,7 +1747,7 @@ static int forward_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
         Pebble *pb;
 
         x = (mida+k)>>1;
-        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
         if (x < 0 || x < k)
           { V[k]  = -2;  // Mark dead
             T[k]  = PATH_INT;
@@ -1903,19 +1927,27 @@ static int forward_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           T  =  _T-vmin;
         }
 
-      if (low >= minp)
-        { NA[low] = NA[low+1];
-          V[low]  = -1;
-        }
-      else
-        low += 1;
+      // Dynamic sequence length constraint for wave expansion
+      { int curr_anti = mida + 2*(dif+1);
+        int seq_minp = curr_anti - 2*blen;
+        int seq_maxp = 2*alen - curr_anti;
+        int eff_minp = (minp > seq_minp) ? minp : seq_minp;
+        int eff_maxp = (maxp < seq_maxp) ? maxp : seq_maxp;
 
-      if (hgh <= maxp)
-        { NA[hgh] = NA[hgh-1];
-          V[hgh]  = am = -1;
-        }
-      else
-        am = V[--hgh];
+        if (low >= eff_minp)
+          { NA[low] = NA[low+1];
+            V[low]  = -1;
+          }
+        else
+          low += 1;
+
+        if (hgh <= eff_maxp)
+          { NA[hgh] = NA[hgh-1];
+            V[hgh]  = am = -1;
+          }
+        else
+          am = V[--hgh];
+      }
 
       dif += 1;
 
@@ -2151,10 +2183,12 @@ static int forward_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
   return (0);
 }
 
-static int reverse_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align, 
+static int reverse_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
                         int mind, int maxd, int mida, int minp, int maxp, int tspace)
 { char *aseq  = align->aseq - 1;
   char *bseq  = align->bseq - 1;
+  int   alen  = align->alen;
+  int   blen  = align->blen;
   Path *apath = align->path;
 
   int     hgh, low, dif;
@@ -2229,7 +2263,7 @@ static int reverse_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
         Pebble *pb;
 
         x = (mida+k)>>1;
-        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
         if (x < 0 || x < k)
           { V[k]  = -2;  // Mark dead
             T[k]  = PATH_INT;
@@ -2405,19 +2439,27 @@ static int reverse_wrap(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           T  =  _T-vmin;
         }
 
-      if (low >= minp)
-        { NA[low] = NA[low+1];
-          V[low]  = ap = INT32_MAX;
-        }
-      else
-        ap = V[++low];
+      // Dynamic sequence length constraint for wave expansion
+      { int curr_anti = mida - 2*(dif+1);
+        int seq_minp = curr_anti - 2*blen;
+        int seq_maxp = 2*alen - curr_anti;
+        int eff_minp = (minp > seq_minp) ? minp : seq_minp;
+        int eff_maxp = (maxp < seq_maxp) ? maxp : seq_maxp;
 
-      if (hgh <= maxp)
-        { NA[hgh] = NA[hgh-1];
-          V[hgh] = INT32_MAX;
-        }
-      else
-        hgh -= 1;
+        if (low >= eff_minp)
+          { NA[low] = NA[low+1];
+            V[low]  = ap = INT32_MAX;
+          }
+        else
+          ap = V[++low];
+
+        if (hgh <= eff_maxp)
+          { NA[hgh] = NA[hgh-1];
+            V[hgh] = INT32_MAX;
+          }
+        else
+          hgh -= 1;
+      }
 
       dif += 1;
 
@@ -2814,6 +2856,8 @@ static int forward_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
                           int midd, int mida, int minp, int maxp)
 { char *aseq  = align->aseq;
   char *bseq  = align->bseq;
+  int   alen  = align->alen;
+  int   blen  = align->blen;
   Path *apath = align->path;
 
   int     hgh, low, dif;
@@ -2892,7 +2936,7 @@ static int forward_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
         Pebble *pb;
 
         x = (mida+k)>>1;
-        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
         if (x < 0 || x < k)
           { V[k]  = -2;  // Mark dead
             T[k]  = PATH_INT;
@@ -3090,19 +3134,27 @@ static int forward_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           T  =  _T-vmin;
         }
 
-      if (low >= minp)
-        { NA[low] = NA[low+1];
-          V[low]  = -1;
-        }
-      else
-        low += 1;
+      // Dynamic sequence length constraint for wave expansion
+      { int curr_anti = mida + 2*(dif+1);
+        int seq_minp = curr_anti - 2*blen;
+        int seq_maxp = 2*alen - curr_anti;
+        int eff_minp = (minp > seq_minp) ? minp : seq_minp;
+        int eff_maxp = (maxp < seq_maxp) ? maxp : seq_maxp;
 
-      if (hgh <= maxp)
-        { NA[hgh] = NA[hgh-1];
-          V[hgh]  = am = -1;
-        }
-      else
-        am = V[--hgh];
+        if (low >= eff_minp)
+          { NA[low] = NA[low+1];
+            V[low]  = -1;
+          }
+        else
+          low += 1;
+
+        if (hgh <= eff_maxp)
+          { NA[hgh] = NA[hgh-1];
+            V[hgh]  = am = -1;
+          }
+        else
+          am = V[--hgh];
+      }
 
       dif += 1;
 
@@ -3154,7 +3206,7 @@ static int forward_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           b <<= 1;
 
           x = (c+k)>>1;
-          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
           if (x < 0 || x < k)
             { t  = T[k];
               n  = M[k];
@@ -3362,6 +3414,8 @@ static int reverse_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
                           int midd, int mida, int minp, int maxp)
 { char *aseq  = align->aseq - 1;
   char *bseq  = align->bseq - 1;
+  int   alen  = align->alen;
+  int   blen  = align->blen;
   Path *apath = align->path;
 
   int     hgh, low, dif;
@@ -3438,7 +3492,7 @@ static int reverse_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
         Pebble *pb;
 
         x = (mida+k)>>1;
-        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+        // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
         if (x < 0 || x < k)
           { V[k]  = -2;  // Mark dead
             T[k]  = PATH_INT;
@@ -3627,19 +3681,27 @@ static int reverse_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           T  =  _T-vmin;
         }
 
-      if (low >= minp)
-        { NA[low] = NA[low+1];
-          V[low]  = ap = INT32_MAX;
-        }
-      else
-        ap = V[++low];
+      // Dynamic sequence length constraint for wave expansion
+      { int curr_anti = mida - 2*(dif+1);
+        int seq_minp = curr_anti - 2*blen;
+        int seq_maxp = 2*alen - curr_anti;
+        int eff_minp = (minp > seq_minp) ? minp : seq_minp;
+        int eff_maxp = (maxp < seq_maxp) ? maxp : seq_maxp;
 
-      if (hgh <= maxp)
-        { NA[hgh] = NA[hgh-1];
-          V[hgh] = INT32_MAX;
-        }
-      else
-        hgh -= 1;
+        if (low >= eff_minp)
+          { NA[low] = NA[low+1];
+            V[low]  = ap = INT32_MAX;
+          }
+        else
+          ap = V[++low];
+
+        if (hgh <= eff_maxp)
+          { NA[hgh] = NA[hgh-1];
+            V[hgh] = INT32_MAX;
+          }
+        else
+          hgh -= 1;
+      }
 
       dif += 1;
 
@@ -3691,7 +3753,7 @@ static int reverse_extend(_Work_Data *work, _Align_Spec *spec, Alignment *align,
           b <<= 1;
 
           x = (c+k)>>1;
-          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x])
+          // Bounds check: x must be >= 0 (for aseq[x]) and >= k (for bs[x]=bseq[y])
           if (x < 0 || x < k)
             { t  = T[k];
               n  = M[k];


### PR DESCRIPTION
Root cause analysis:
- Wave algorithm uses diagonal coordinate system where k = x - y
- For valid coordinates: x = (anti+k)/2 >= 0 and y = (anti-k)/2 >= 0
- This requires k to be in range [-anti, anti]
- Original code only checked hgh <= anti (y >= 0), not low >= -anti (x >= 0)

Fixes applied:

1. Entry point validation (Local_Alignment, Wrap_Around_Alignment, Find_Extension):
   - Add check: while (((anti+low)>>1) < 0) low += 1
   - Constrain minp to -anti (prevents wave expansion into x < 0 region)
   - Constrain maxp to anti (prevents wave expansion into y < 0 region)
   - Return error if no valid diagonals remain (low > hgh)

2. Internal bounds checking (all 6 wave functions):
   - Add check: if (x < 0 || x < k) mark diagonal as dead
   - Applied to both 0-wave initialization and main wave loops

3. Safety checks (forward_wave, reverse_wave):
   - Add check: if (avail == 0) return error
   - Catches case where all diagonals fail bounds checking

4. Early termination (all wave expansion loops):
   - Add check: if (hgh < low) break
   - Prevents infinite loops when all diagonals are trimmed

This multi-layer fix prevents invalid coordinates from being computed, rather than just detecting and skipping them after the fact.