### PR TITLE
README: add Bioconda badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # FastGA: A Fast Genome Aligner
+
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://bioconda.github.io/recipes/fastga/README.html)
+[![Anaconda-Server Badge](https://anaconda.org/bioconda/fastga/badges/version.svg)](https://anaconda.org/bioconda/fastga)
+[![Anaconda-Server Badge](https://anaconda.org/bioconda/fastga/badges/downloads.svg)](https://anaconda.org/bioconda/fastga)
+
   
 <font size ="4">**_Authors:  Gene Myers & Chenxi Zhou_**<br>
 **_First:   May 10, 2023_**<br>


### PR DESCRIPTION
FastGA is available on [Bioconda](https://bioconda.github.io/recipes/fastga/README.html) and can be installed with:

```
conda install -c conda-forge -c bioconda fastga
```

This PR adds the standard Bioconda badges near the top of the README so users can discover the conda install. The badges link to the Bioconda recipe and show the current package version and download count.

The change is minimal: three badge lines inserted immediately after the title heading. No existing content was altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)